### PR TITLE
feat: migrate docker-cd app config

### DIFF
--- a/apps/backrest/docker-cd.yml
+++ b/apps/backrest/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/backrest/docker-compose.yml
+++ b/apps/backrest/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 # force
 services:
   backrest:

--- a/apps/bang-pr-373/docker-cd.yml
+++ b/apps/bang-pr-373/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/bang-pr-373/docker-compose.yml
+++ b/apps/bang-pr-373/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   bang:
     image: ghcr.io/wajeht/bang:c79998d@sha256:c6c7973dd2ae2db741f1cb81eb1f96c0265b7fadafc874830382f45a4204afd5

--- a/apps/bang/docker-cd.yml
+++ b/apps/bang/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/bang/docker-compose.yml
+++ b/apps/bang/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   bang:
     image: ghcr.io/wajeht/bang:30261a2@sha256:0b8ea0094b284c8ce02b398898b5b2674eba300064500d48fef0d45ba0f01aeb

--- a/apps/bazarr/docker-cd.yml
+++ b/apps/bazarr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/bazarr/docker-compose.yml
+++ b/apps/bazarr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   bazarr:
     container_name: bazarr

--- a/apps/beszel/docker-cd.yml
+++ b/apps/beszel/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/beszel/docker-compose.yml
+++ b/apps/beszel/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   beszel:
     container_name: beszel

--- a/apps/byparr/docker-cd.yml
+++ b/apps/byparr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/byparr/docker-compose.yml
+++ b/apps/byparr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   byparr:
     image: ghcr.io/thephaseless/byparr:2.1.0@sha256:01a46a2865d9a6db5eb8ead04ec0dd33b8fbe233e8565ae70b50d4cc0af4cfb0

--- a/apps/calendar/docker-cd.yml
+++ b/apps/calendar/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/calendar/docker-compose.yml
+++ b/apps/calendar/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   calendar:
     image: ghcr.io/wajeht/calendar:397e09e@sha256:ec5dc5a8eb5be6ead69eae1088e552a2b9427a36f3000d38283fb12612f2b2a7

--- a/apps/cap/docker-cd.yml
+++ b/apps/cap/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/cap/docker-compose.yml
+++ b/apps/cap/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   cap:
     container_name: cap

--- a/apps/clear-renovate-notifications/docker-cd.yml
+++ b/apps/clear-renovate-notifications/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/clear-renovate-notifications/docker-compose.yml
+++ b/apps/clear-renovate-notifications/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   # lint-ignore: backup  # stateless — polls GitHub notifications, no persistent data
   clear-renovate-notifications:

--- a/apps/close-powerlifting/docker-cd.yml
+++ b/apps/close-powerlifting/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: [close-powerlifting]

--- a/apps/close-powerlifting/docker-compose.yml
+++ b/apps/close-powerlifting/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: [close-powerlifting]
+
 services:
   close-powerlifting:
     image: ghcr.io/wajeht/close-powerlifting:44098a0@sha256:58f2f832caee7412611d77f254f12079aa4600ce23b70b5fbd16ca57c97e77d9

--- a/apps/commit/docker-cd.yml
+++ b/apps/commit/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/commit/docker-compose.yml
+++ b/apps/commit/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   commit:
     image: ghcr.io/wajeht/commit:3d7cb2b@sha256:3ea8f8de0265a864f2a5b5ee052ddd6de6614f2bdb9f647ff16bf307c9528281

--- a/apps/convertx/docker-cd.yml
+++ b/apps/convertx/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/convertx/docker-compose.yml
+++ b/apps/convertx/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   convertx:
     container_name: convertx

--- a/apps/dbgate/docker-cd.yml
+++ b/apps/dbgate/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/dbgate/docker-compose.yml
+++ b/apps/dbgate/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   dbgate:
     container_name: dbgate

--- a/apps/ddns-updater/docker-cd.yml
+++ b/apps/ddns-updater/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/ddns-updater/docker-compose.yml
+++ b/apps/ddns-updater/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   # lint-ignore: backup  # stateless — last-known-IP cache, auto-rebuilds on startup
   ddns-updater:

--- a/apps/dozzle/docker-cd.yml
+++ b/apps/dozzle/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/dozzle/docker-compose.yml
+++ b/apps/dozzle/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   dozzle:
     container_name: dozzle

--- a/apps/excalidraw/docker-cd.yml
+++ b/apps/excalidraw/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/excalidraw/docker-compose.yml
+++ b/apps/excalidraw/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   excalidraw:
     container_name: excalidraw

--- a/apps/favicon/docker-cd.yml
+++ b/apps/favicon/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/favicon/docker-compose.yml
+++ b/apps/favicon/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   favicon:
     image: ghcr.io/wajeht/favicon:06156a0@sha256:1e0a63308e1082777de600821ff474d14985caaa2c3444627b75662e1c2fec5f

--- a/apps/gains/docker-cd.yml
+++ b/apps/gains/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/gains/docker-compose.yml
+++ b/apps/gains/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   gains:
     image: ghcr.io/wajeht/gains:70caca1@sha256:b7eb603d8142f98f59716a633f7987738f82f988d555a6d9455e5a04199ea835

--- a/apps/garage/docker-cd.yml
+++ b/apps/garage/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/garage/docker-compose.yml
+++ b/apps/garage/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   garage:
     container_name: garage

--- a/apps/gatus/README.md
+++ b/apps/gatus/README.md
@@ -6,8 +6,7 @@
 
 ```
 apps/gatus/
-├── docker-compose.yml
-├── docker-cd.yml          # rolling_update: false
+├── docker-compose.yml     # includes x-docker-cd.rolling_update: false
 ├── config/
 │   └── config.yaml        # endpoints + alerting
 └── httpcheck              # static binary used for container healthcheck

--- a/apps/gatus/docker-cd.yml
+++ b/apps/gatus/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/gatus/docker-compose.yml
+++ b/apps/gatus/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   gatus:
     container_name: gatus

--- a/apps/git/docker-cd.yml
+++ b/apps/git/docker-cd.yml
@@ -1,2 +1,0 @@
-rolling_update: true
-ignore_deployment: true

--- a/apps/git/docker-compose.yml
+++ b/apps/git/docker-compose.yml
@@ -1,3 +1,7 @@
+x-docker-cd:
+  rolling_update: true
+  ignore_deployment: true
+
 services:
   git:
     image: ghcr.io/wajeht/git:1a035e4@sha256:52dfb610fb9d11bbc4050c4a4884c16331feae83939d7280556fa70489ff1837

--- a/apps/gitea/docker-cd.yml
+++ b/apps/gitea/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/gitea/docker-compose.yml
+++ b/apps/gitea/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   mirror-sync:
     container_name: gitea-mirror-sync

--- a/apps/hello-world/docker-cd.yml
+++ b/apps/hello-world/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: [hello-world]

--- a/apps/hello-world/docker-compose.yml
+++ b/apps/hello-world/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: [hello-world]
+
 services:
   hello-world:
     image: ghcr.io/wajeht/hello-world:2c14cba@sha256:f0acd156522350cdbc6ee8752d5dc84b39b07dfb5710df2fa1fc51f87f1b5e82

--- a/apps/homeassistant/docker-cd.yml
+++ b/apps/homeassistant/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/homeassistant/docker-compose.yml
+++ b/apps/homeassistant/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   homeassistant:
     container_name: homeassistant

--- a/apps/homepage/docker-cd.yml
+++ b/apps/homepage/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/homepage/docker-compose.yml
+++ b/apps/homepage/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   homepage:
     container_name: homepage

--- a/apps/immich/docker-cd.yml
+++ b/apps/immich/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/immich/docker-compose.yml
+++ b/apps/immich/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 # force
 services:
   immich:

--- a/apps/ip/docker-cd.yml
+++ b/apps/ip/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/ip/docker-compose.yml
+++ b/apps/ip/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   ip:
     image: ghcr.io/wajeht/ip:20d0c8a@sha256:775b5c378b4a024aeb4c4d14e019bf793aabdac193d59179012bccddf6e6ffa0

--- a/apps/jaw-dev/docker-cd.yml
+++ b/apps/jaw-dev/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/jaw-dev/docker-compose.yml
+++ b/apps/jaw-dev/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   www:
     image: ghcr.io/wajeht/jaw.dev:72399f7@sha256:e37764a1c51f8aff076a23970557f73df87b293b3d4eb49000ff0bb7e34dabfc

--- a/apps/jellyfin/docker-cd.yml
+++ b/apps/jellyfin/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   jellyfin:
     image: linuxserver/jellyfin:10.11.10ubu2404-ls34@sha256:c0ed73678fb4ca761e0d940a92e49b95352f7f241a9be79a2c575c0099288f46

--- a/apps/linx/docker-cd.yml
+++ b/apps/linx/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/linx/docker-compose.yml
+++ b/apps/linx/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   linx:
     container_name: linx

--- a/apps/miniflux/docker-cd.yml
+++ b/apps/miniflux/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/miniflux/docker-compose.yml
+++ b/apps/miniflux/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   miniflux:
     container_name: miniflux

--- a/apps/mm2us/docker-cd.yml
+++ b/apps/mm2us/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/mm2us/docker-compose.yml
+++ b/apps/mm2us/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   mm2us:
     image: ghcr.io/wajeht/mm2us.com:1be9380@sha256:4529c72fddeb18b81313849f3cdebb8bb4b00c89f4bcd38b97d83a9bdbd454c2

--- a/apps/notify/docker-cd.yml
+++ b/apps/notify/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/notify/docker-compose.yml
+++ b/apps/notify/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   notify:
     image: ghcr.io/wajeht/notify:668a78d@sha256:ead918f1827b845c60c4af24ad57b955826bec1952e39a91b7fa8c93d99af0e9

--- a/apps/ntfy/docker-cd.yml
+++ b/apps/ntfy/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/ntfy/docker-compose.yml
+++ b/apps/ntfy/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   ntfy:
     container_name: ntfy

--- a/apps/oauth2-proxy/docker-cd.yml
+++ b/apps/oauth2-proxy/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/oauth2-proxy/docker-compose.yml
+++ b/apps/oauth2-proxy/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   oauth2-admin:
     container_name: oauth2-admin

--- a/apps/plex/docker-cd.yml
+++ b/apps/plex/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/plex/docker-compose.yml
+++ b/apps/plex/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   plex:
     image: linuxserver/plex:1.43.2.10687-563d026ea-ls307@sha256:626eb0d52b4522db3be91110a89161be6ccffc0741e9abf0e93aaf4fea98ccb9

--- a/apps/power-badge/docker-cd.yml
+++ b/apps/power-badge/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/power-badge/docker-compose.yml
+++ b/apps/power-badge/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   power-badge:
     image: ghcr.io/wajeht/power-badge:9b3509d@sha256:5aa17b52b3783e066a0fefa5e51e0cbefd481c34f344cfec26a7302a39508006

--- a/apps/prowlarr/docker-cd.yml
+++ b/apps/prowlarr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/prowlarr/docker-compose.yml
+++ b/apps/prowlarr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 # force
 services:
   prowlarr:

--- a/apps/radarr/docker-cd.yml
+++ b/apps/radarr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/radarr/docker-compose.yml
+++ b/apps/radarr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   radarr:
     image: linuxserver/radarr:6.2.1-develop@sha256:470e93728e0b2d12ed2f8328fcdfdfc509465329e94f20fb5404a9f2e548ab6b

--- a/apps/renovate/docker-cd.yml
+++ b/apps/renovate/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/renovate/docker-compose.yml
+++ b/apps/renovate/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   # lint-ignore: backup  # stateless — PR cache, rebuilds from git remotes on next run
   renovate:

--- a/apps/sabnzbd/docker-cd.yml
+++ b/apps/sabnzbd/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/sabnzbd/docker-compose.yml
+++ b/apps/sabnzbd/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   sabnzbd:
     image: linuxserver/sabnzbd:5.0.4-unstable@sha256:83bd4ddd4cca0056380834c8486aafd74086de4e15ae5abb867bb75a3e72908e

--- a/apps/screenshot/docker-cd.yml
+++ b/apps/screenshot/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/screenshot/docker-compose.yml
+++ b/apps/screenshot/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   screenshot:
     image: ghcr.io/wajeht/screenshot:a35b098@sha256:be083b78b85328611af47fdf1ccf06634949bf0a9ea1c459957eafbe92d0bed9

--- a/apps/seerr/docker-cd.yml
+++ b/apps/seerr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/seerr/docker-compose.yml
+++ b/apps/seerr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   seerr:
     container_name: seerr

--- a/apps/sonarr/docker-cd.yml
+++ b/apps/sonarr/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/sonarr/docker-compose.yml
+++ b/apps/sonarr/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   sonarr:
     image: linuxserver/sonarr:4.0.17.2952-ls312@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b

--- a/apps/traefik/docker-cd.yml
+++ b/apps/traefik/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 # force
 services:
   traefik:

--- a/apps/ufc/docker-cd.yml
+++ b/apps/ufc/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: true

--- a/apps/ufc/docker-compose.yml
+++ b/apps/ufc/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: true
+
 services:
   ufc:
     image: ghcr.io/wajeht/ufc:d758277@sha256:7b4f4f35fc6a8257d15fd21e7bd6708dabbe4b5f68cc4b907fe2af7c8c102224

--- a/apps/umami/docker-cd.yml
+++ b/apps/umami/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/umami/docker-compose.yml
+++ b/apps/umami/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   umami:
     container_name: umami

--- a/apps/vaultwarden/docker-cd.yml
+++ b/apps/vaultwarden/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/vaultwarden/docker-compose.yml
+++ b/apps/vaultwarden/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   vaultwarden:
     container_name: vaultwarden

--- a/apps/vpn-qbit/docker-cd.yml
+++ b/apps/vpn-qbit/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/vpn-qbit/docker-compose.yml
+++ b/apps/vpn-qbit/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   gluetun:
     image: qmcgaw/gluetun:v3.41@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab

--- a/apps/walker/docker-cd.yml
+++ b/apps/walker/docker-cd.yml
@@ -1,2 +1,0 @@
-rolling_update: false
-ignore_deployment: true

--- a/apps/walker/docker-compose.yml
+++ b/apps/walker/docker-compose.yml
@@ -1,3 +1,7 @@
+x-docker-cd:
+  rolling_update: false
+  ignore_deployment: true
+
 services:
   # lint-ignore: backup  # cache-only (just a small JSON of configured repos, auto-regenerates)
   walker:

--- a/apps/zepp/docker-cd.yml
+++ b/apps/zepp/docker-cd.yml
@@ -1,2 +1,0 @@
-rolling_update: false
-ignore_deployment: true

--- a/apps/zepp/docker-compose.yml
+++ b/apps/zepp/docker-compose.yml
@@ -1,3 +1,7 @@
+x-docker-cd:
+  rolling_update: false
+  ignore_deployment: true
+
 services:
   zepp:
     image: ghcr.io/wajeht/zepp:ae7ebb1@sha256:0ff4770f6c4b46598edf1e60873423861a2a336c19273a1a80f08f17958c9430

--- a/apps/zigbee2mqtt/docker-cd.yml
+++ b/apps/zigbee2mqtt/docker-cd.yml
@@ -1,1 +1,0 @@
-rolling_update: false

--- a/apps/zigbee2mqtt/docker-compose.yml
+++ b/apps/zigbee2mqtt/docker-compose.yml
@@ -1,3 +1,6 @@
+x-docker-cd:
+  rolling_update: false
+
 services:
   zigbee2mqtt:
     image: ghcr.io/koenkk/zigbee2mqtt:2.12.0@sha256:1debff565ab6841417bd9f7ce8ad44f8c5f25a8b02a24ce3fd79e4779a4763a5

--- a/docs/adding-apps.md
+++ b/docs/adding-apps.md
@@ -9,6 +9,7 @@ For secrets, see [Secrets](secrets.md). For backups, see [Disaster Recovery](dis
 Before pushing a new app:
 
 - `docker-compose.yml` lives in `apps/<name>/`
+- docker-cd app config lives in top-level `x-docker-cd` inside Compose
 - service has `restart`, `init`, healthcheck, logging, and resource limits
 - container drops capabilities and uses `no-new-privileges`
 - internet-facing app is on the external `traefik` network
@@ -26,6 +27,9 @@ mkdir -p apps/myapp
 Create `apps/myapp/docker-compose.yml`:
 
 ```yaml
+x-docker-cd:
+  rolling_update: false
+
 services:
   myapp:
     image: nginx:1.25
@@ -369,12 +373,15 @@ To back up a new app, add a repo + plan to `apps/backrest/config/config.json`. P
 
 ## Disable Rolling Deploy
 
-For apps that cannot run multiple instances:
-
-Create `apps/myapp/docker-cd.yml`:
+For apps that cannot run multiple instances, add top-level app config to `apps/myapp/docker-compose.yml`:
 
 ```yaml
-rolling_update: false
+x-docker-cd:
+  rolling_update: false
+
+services:
+  myapp:
+    image: nginx:1.25
 ```
 
 ## Apps Behind Reverse Proxy

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -40,10 +40,9 @@ RESTIC_PASSWORD               # In apps/backrest/.env.sops — without it, NO re
 
 ```
 apps/backrest/
-├── docker-compose.yml      # Backrest service
+├── docker-compose.yml      # Backrest service + x-docker-cd.rolling_update: false
 ├── config/
 │   └── config.json         # repos + plans
-├── docker-cd.yml           # rolling_update: false
 └── .env.sops               # RESTIC_PASSWORD
 ```
 
@@ -212,7 +211,7 @@ Plex has spaces in its paths (`Library/Application Support/...`) — wrap each p
 
 ### Plan: App Without `container_name`
 
-If the app uses `rolling_update: true`, adding `container_name` breaks rolling updates because Docker can't have two containers with the same name during the swap. Use an ephemeral container instead:
+If the app uses `x-docker-cd.rolling_update: true`, adding `container_name` breaks rolling updates because Docker can't have two containers with the same name during the swap. Use an ephemeral container instead:
 
 ```json
 "command": "docker run --rm -v /home/jaw/data/bang:/data keinos/sqlite3:3.51.3@sha256:520cfebb116119cc642b72d72c3ff948cc120a891dc4d83824c664f1ca65a354 sqlite3 /data/db.sqlite \".backup /data/.bang.bak\""
@@ -605,7 +604,7 @@ Known issues and their fixes.
 | `mkdir /data/processlogs: permission denied`                                               | Backrest container can't write to bind-mounted `/data`                                    | Verify `cap_add` includes `DAC_OVERRIDE`. `DAC_READ_SEARCH` alone is insufficient.                                                |
 | `Tini is not running as PID 1` warning on startup                                          | `init: true` set on the compose service — wraps Backrest's tini twice                     | Remove `init: true`. The image already has tini at PID 1.                                                                         |
 | Backrest tries to rewrite config.json on every startup                                     | `version` field doesn't match current schema, Backrest tries to migrate it                | Set `"version": 6` explicitly in config.json so Backrest sees the current schema.                                                 |
-| Hook fails with `No such container: <app>`                                                 | App container has no `container_name:` set; docker generates `bang-bang-1`-style names    | Add `container_name:` to the app compose with `rolling_update: false`, OR use an ephemeral container in the hook                  |
+| Hook fails with `No such container: <app>`                                                 | App container has no `container_name:` set; docker generates `bang-bang-1`-style names    | Add `container_name:` to the app compose with `x-docker-cd.rolling_update: false`, OR use an ephemeral container in the hook                  |
 | Want both `container_name:` AND rolling updates                                            | Impossible — can't have two containers with the same name during the rolling swap         | Pick one. If rolling-update matters (instant-deploy apps), use ephemeral container approach instead.                              |
 | sqlite3 backup fails immediately under concurrent writes                                   | No retry budget configured                                                                | Add `-cmd ".timeout 30000"` before the `.backup` command                                                                          |
 | Spaces in DB path break the hook                                                           | Shell word-splitting on unquoted paths                                                    | Wrap each path in **single quotes**. JSON escapes inside double-quoted strings only escape the JSON, not the shell.               |

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -53,6 +53,17 @@ check_sops() {
 }
 
 # shellcheck disable=SC2329
+check_docker_cd_app_config() {
+	local legacy=() f
+	while IFS= read -r -d '' f; do
+		legacy+=("$f: move app config to top-level x-docker-cd in docker-compose.yml")
+	done < <(find apps -mindepth 2 -maxdepth 2 -name 'docker-cd.yml' -print0)
+	if [ "${#legacy[@]}" -gt 0 ]; then
+		printf '%s\n' "${legacy[@]}"
+		return 1
+	fi
+}
+# shellcheck disable=SC2329
 check_hardening() {
 	local missing=() f
 	while IFS= read -r -d '' f; do
@@ -311,6 +322,7 @@ check_resources() {
 printf '\n%s==>%s %slint%s\n' "$BOLD$CYAN" "$RESET" "$BOLD" "$RESET"
 run_check "shell scripts" check_shell
 run_check "sops encryption" check_sops
+run_check "docker-cd app config" check_docker_cd_app_config
 run_check "container hardening" check_hardening
 run_check "service hygiene" check_service_hygiene
 run_check "backup plans" check_backup


### PR DESCRIPTION
## Summary
- upgrade docker-cd to v0.3.0
- move app deploy config from per-app docker-cd.yml files into top-level x-docker-cd in docker-compose.yml
- remove legacy app docker-cd.yml files and add a lint guard against reintroducing them
- update docs for the new config location

## Checks
- ./scripts/lint.sh
- git diff --check