### PR TITLE
chore: simplify docker-cd update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: setup install install-fresh uninstall update update-force status relogin cloudflare format lint push fix-git images images-prune clean update-submodules nfs-mount nfs-unmount nfs-persist nfs-unpersist nfs-status help
+.PHONY: setup install install-fresh uninstall update status relogin cloudflare format lint push fix-git images images-prune clean update-submodules nfs-mount nfs-unmount nfs-persist nfs-unpersist nfs-status help
 
 ## setup                   Create data dirs and base setup
 setup:
@@ -18,13 +18,9 @@ install-fresh:
 uninstall:
 	@./scripts/setup.sh uninstall
 
-## update                  Pull latest and redeploy docker-cd
+## update                  Force recreate docker-cd
 update:
 	@./scripts/setup.sh update
-
-## update-force            Force recreate docker-cd
-update-force:
-	@./scripts/setup.sh update-force
 
 ## status                  Show services, mounts, and disk usage
 status:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,11 +42,10 @@ docker-cd should start first, then deploy the rest of `apps/*`.
 ## Common Commands
 
 ```bash
-./scripts/setup.sh update        # Pull latest and redeploy docker-cd
-./scripts/setup.sh update-force  # Force-recreate docker-cd
-./scripts/setup.sh nfs mount     # Mount NFS shares
-./scripts/setup.sh nfs persist   # Persist NFS mounts
-./scripts/cloudflare.sh          # Update Cloudflare IP allowlists
+./scripts/setup.sh update       # Pull latest and force-recreate docker-cd
+./scripts/setup.sh nfs mount    # Mount NFS shares
+./scripts/setup.sh nfs persist  # Persist NFS mounts
+./scripts/cloudflare.sh         # Update Cloudflare IP allowlists
 ```
 
 ## OS Tuning

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -540,7 +540,7 @@ cmd_relogin() {
 }
 
 #=============================================================================
-# UPDATE - Redeploy docker-cd (which manages all other services)
+# UPDATE - Force-recreate docker-cd (which manages all other services)
 #=============================================================================
 prepare_update() {
 	require_cmd docker
@@ -559,17 +559,11 @@ prepare_update() {
 }
 
 cmd_update() {
-	local force=${1:-0}
-	header "Updating docker-cd"
+	header "Force-updating docker-cd"
 	prepare_update
 
-	if [ "$force" = "1" ]; then
-		step "1/1" "Force-redeploying docker-cd..."
-		redeploy_compose "$DOCKER_CD_DIR" docker-cd 1
-	else
-		step "1/1" "Redeploying docker-cd..."
-		redeploy_compose "$DOCKER_CD_DIR" docker-cd
-	fi
+	step "1/1" "Force-redeploying docker-cd..."
+	redeploy_compose "$DOCKER_CD_DIR" docker-cd 1
 
 	header "Done"
 }
@@ -695,8 +689,7 @@ print_usage() {
 	printf '%b\n' "  ${GREEN}install-fresh${NC}            Reset docker-cd state, then deploy all services"
 	printf '%b\n' "  ${GREEN}uninstall${NC}                Remove all services and cleanup"
 	printf '%b\n' "  ${GREEN}relogin${NC}                  Refresh docker registry credentials"
-	printf '%b\n' "  ${GREEN}update${NC}                   Redeploy docker-cd"
-	printf '%b\n' "  ${GREEN}update-force${NC}             Force-recreate docker-cd"
+	printf '%b\n' "  ${GREEN}update${NC}                   Force-recreate docker-cd"
 	printf '%b\n' "  ${GREEN}images${NC}                   Show unused Docker images and volumes"
 	printf '%b\n' "  ${GREEN}images prune${NC}             Remove unused images and orphan volumes"
 	printf '%b\n' "  ${GREEN}update-submodules${NC}        Update submodules to latest and commit"
@@ -708,7 +701,7 @@ print_usage() {
 	printf '%b\n' "  ${DIM}$0 nfs mount plex${NC}        # Mount only plex"
 	printf '%b\n' "  ${DIM}$0 install${NC}               # Deploy everything"
 	printf '%b\n' "  ${DIM}$0 install-fresh${NC}         # Force full docker-cd app reconcile"
-	printf '%b\n' "  ${DIM}$0 update-force${NC}          # Force-recreate docker-cd"
+	printf '%b\n' "  ${DIM}$0 update${NC}                # Force-recreate docker-cd"
 	printf '%b\n' "  ${DIM}$0 status${NC}                # Show status"
 }
 
@@ -741,9 +734,6 @@ case "${1:-}" in
 		;;
 	update)
 		cmd_update
-		;;
-	update-force)
-		cmd_update 1
 		;;
 	images)
 		shift


### PR DESCRIPTION
## Summary
- keep one manual docker-cd recovery command: `make update`
- make `./scripts/setup.sh update` force-recreate docker-cd by default
- remove the separate `update-force` command name
- update quick-start docs

## Tests
- `bash -n scripts/setup.sh`
- `./scripts/setup.sh help`
- `make help`
- `./scripts/lint.sh`
- `git diff --check`