### PR TITLE
fix: remove ignored deployment apps

### DIFF
--- a/apps/git/docker-compose.yml
+++ b/apps/git/docker-compose.yml
@@ -1,6 +1,5 @@
 x-docker-cd:
   rolling_update: true
-  ignore_deployment: true
 
 services:
   git:

--- a/apps/walker/docker-compose.yml
+++ b/apps/walker/docker-compose.yml
@@ -1,6 +1,5 @@
 x-docker-cd:
   rolling_update: false
-  ignore_deployment: true
 
 services:
   # lint-ignore: backup  # cache-only (just a small JSON of configured repos, auto-regenerates)

--- a/apps/zepp/docker-compose.yml
+++ b/apps/zepp/docker-compose.yml
@@ -1,6 +1,5 @@
 x-docker-cd:
   rolling_update: false
-  ignore_deployment: true
 
 services:
   zepp:

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -87,7 +87,7 @@ Per-app schedules are staggered to prevent resource contention. `global` runs la
 | vaultwarden   | 4:00 AM  | SQLite + files       | DB file is `db.sqlite3`                                                                    |
 | gitea         | 4:10 AM  | SQLite + files       | DB at `gitea/gitea.db`. Includes all git repos                                             |
 | jellyfin      | 4:20 AM  | SQLite x2 + files    | DBs at `data/jellyfin.db` + `data/library.db`. Excludes cache, logs, transcodes, subtitles |
-| zepp          | 4:30 AM  | SQLite DB only       | DB at `db.sqlite`. App is `ignore_deployment: true`; data still backed up.                 |
+| zepp          | 4:30 AM  | SQLite DB only       | DB at `db.sqlite`.                                                                         |
 | cap           | 4:40 AM  | Redis RDB only       | `redis-cli SAVE` hook, then snapshot `dump.rdb`                                            |
 | umami         | 4:50 AM  | Postgres DB only     | `pg_dump` via `docker exec umami-db`                                                       |
 | miniflux      | 5:00 AM  | Postgres DB only     | `pg_dump` via `docker exec miniflux-db`                                                    |


### PR DESCRIPTION
Removes deprecated docker-cd ignore_deployment config from managed apps and updates the disaster recovery note. Validation: ./scripts/lint.sh