### PR TITLE
chore: show docker-cd notification versions

### DIFF
--- a/apps/ntfy/templates/docker-cd.yml
+++ b/apps/ntfy/templates/docker-cd.yml
@@ -13,6 +13,15 @@ message: |
   {{- if .strategy }}
   **strategy:** {{ .strategy }}
   {{- end }}
+  {{- if .version }}
+  **version:** {{ .version }}
+  {{- end }}
+  {{- if .previousVersion }}
+  **previous version:** {{ .previousVersion }}
+  {{- end }}
+  {{- if .targetVersion }}
+  **target version:** {{ .targetVersion }}
+  {{- end }}
   {{- if .service }}
   **service:** {{ .service }}
   {{- end }}


### PR DESCRIPTION
## Summary
- render docker-cd notification version fields in the ntfy markdown template
- show previous and target versions when docker-cd sends them

## Tests
- ./scripts/lint.sh