### PR TITLE
chore: update docker-cd to v0.8.4

### DIFF
--- a/apps/docker-cd/docker-compose.yml
+++ b/apps/docker-cd/docker-compose.yml
@@ -4,7 +4,7 @@ x-docker-cd:
 services:
   docker-cd:
     # lint-ignore: backup  # state/cache only, can be rebuilt from Git and Docker
-    image: ghcr.io/wajeht/docker-cd:v0.8.3@sha256:08246b0c51e223ad507c98a7cc80835a6ba81c590d7c13a04245b315318a2e37
+    image: ghcr.io/wajeht/docker-cd:v0.8.4@sha256:629ed131d938d5581ab849c5afaa58c2d64a028d170de5950467a7e9d7356a51
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /home/jaw/data/docker-cd:/home/jaw/data/docker-cd


### PR DESCRIPTION
Summary: Update apps/docker-cd to ghcr.io/wajeht/docker-cd:v0.8.4 and pin the v0.8.4 manifest digest. Validation: ./scripts/lint.sh