### PR TITLE
chore: update docker-cd deployment

### DIFF
--- a/apps/docker-cd/docker-compose.yml
+++ b/apps/docker-cd/docker-compose.yml
@@ -4,7 +4,7 @@ x-docker-cd:
 services:
   docker-cd:
     # lint-ignore: backup  # state/cache only, can be rebuilt from Git and Docker
-    image: ghcr.io/wajeht/docker-cd:v0.8.6@sha256:6e76b855fe5b2c6c3782f09ca50fad90d06cca79278006c1dc2c1cdd11c894c8
+    image: ghcr.io/wajeht/docker-cd:v0.8.7@sha256:8a813253de7a95ecb99e2df98af41b9f5c65cf8ab2af44bd70bdd8af4c91554f
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /home/jaw/data/docker-cd:/home/jaw/data/docker-cd

--- a/apps/ntfy/templates/docker-cd.yml
+++ b/apps/ntfy/templates/docker-cd.yml
@@ -13,14 +13,23 @@ message: |
   {{- if .strategy }}
   **strategy:** {{ .strategy }}
   {{- end }}
-  {{- if .version }}
-  **version:** {{ .version }}
+  {{- if .dockerCdVersion }}
+  **docker-cd version:** {{ .dockerCdVersion }}
+  {{- end }}
+  {{- if .appVersion }}
+  **app version:** {{ .appVersion }}
+  {{- end }}
+  {{- if .serviceVersions }}
+  **service versions:**
+  {{- range $service, $version := .serviceVersions }}
+  - **{{ $service }}:** {{ $version }}
+  {{- end }}
   {{- end }}
   {{- if .previousVersion }}
-  **previous version:** {{ .previousVersion }}
+  **previous docker-cd version:** {{ .previousVersion }}
   {{- end }}
   {{- if .targetVersion }}
-  **target version:** {{ .targetVersion }}
+  **target docker-cd version:** {{ .targetVersion }}
   {{- end }}
   {{- if .service }}
   **service:** {{ .service }}


### PR DESCRIPTION
## Summary

- update docker-cd to v0.8.7 with the pinned GHCR index digest
- update the ntfy docker-cd template for dockerCdVersion, appVersion, serviceVersions, and self-update version fields

## Checks

- npx oxfmt --check on YAML, Markdown, and JSON files
- shfmt -d on shell files under scripts and apps
- ./scripts/lint.sh

Note: local repo root still has unrelated untracked apps/adguard/ files, so full checks were run from a clean temp worktree.