### PR TITLE
fix: clean up docker-cd notification versions

### DIFF
--- a/apps/ntfy/templates/docker-cd.yml
+++ b/apps/ntfy/templates/docker-cd.yml
@@ -19,10 +19,10 @@ message: |
   {{- if .appVersion }}
   **app version:** {{ .appVersion }}
   {{- end }}
-  {{- if .serviceVersions }}
+  {{- if and .serviceVersions (not .appVersion) }}
   **service versions:**
   {{- range $service, $version := .serviceVersions }}
-  - **{{ $service }}:** {{ $version }}
+  **{{ $service }} version:** {{ $version }}
   {{- end }}
   {{- end }}
   {{- if .previousVersion }}


### PR DESCRIPTION
## Summary

- hide per-service versions when a shared appVersion is already present
- render fallback per-service versions without markdown bullets to avoid ntfy spacing gaps

## Checks

- npx oxfmt --check "**/*.{yml,yaml,md,json}"
- find scripts apps -name '*.sh' -print0 | xargs -0 shfmt -d -i 0 -ci
- ./scripts/lint.sh