### PR TITLE
fix: hide duplicate docker-cd service field

### DIFF
--- a/apps/ntfy/templates/docker-cd.yml
+++ b/apps/ntfy/templates/docker-cd.yml
@@ -31,7 +31,7 @@ message: |
   {{- if .targetVersion }}
   **target docker-cd version:** {{ .targetVersion }}
   {{- end }}
-  {{- if .service }}
+  {{- if and .service (not .services) }}
   **service:** {{ .service }}
   {{- end }}
   {{- if .services }}


### PR DESCRIPTION
## Summary

- hide the singular docker-cd `service` line when `services` is already present

## Checks

- npx oxfmt --check "**/*.{yml,yaml,md,json}"
- find scripts apps -name '*.sh' -print0 | xargs -0 shfmt -d -i 0 -ci
- ./scripts/lint.sh