### PR TITLE
feat: add cross-play Minecraft server

### DIFF
--- a/apps/backrest/config/config.json
+++ b/apps/backrest/config/config.json
@@ -546,6 +546,24 @@
       }
     },
     {
+      "id": "minecraft",
+      "uri": "/repos/minecraft",
+      "password": "",
+      "autoInitialize": true,
+      "prunePolicy": {
+        "schedule": {
+          "cron": "0 6 * * 0"
+        },
+        "maxUnusedPercent": 10
+      },
+      "checkPolicy": {
+        "schedule": {
+          "cron": "0 7 * * 0"
+        },
+        "structureOnly": true
+      }
+    },
+    {
       "id": "global",
       "uri": "/repos/global",
       "password": "",
@@ -2049,6 +2067,55 @@
           "actionShoutrrr": {
             "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=sonarr+backup+FAILED&priority=Max&tags=skull",
             "template": "sonarr backup failed{{ if .Error }}: {{ .Error }}{{ end }}"
+          }
+        }
+      ]
+    },
+    {
+      "id": "minecraft",
+      "repo": "minecraft",
+      "paths": ["/source/minecraft"],
+      "excludes": ["**/minecraft/logs", "**/minecraft/cache", "**/minecraft/.cache"],
+      "schedule": {
+        "cron": "50 23 * * *",
+        "clock": "CLOCK_LOCAL"
+      },
+      "retention": {
+        "policyTimeBucketed": {
+          "daily": 7,
+          "weekly": 4,
+          "monthly": 6
+        }
+      },
+      "hooks": [
+        {
+          "conditions": ["CONDITION_SNAPSHOT_START"],
+          "onError": "ON_ERROR_CANCEL",
+          "actionCommand": {
+            "command": "docker exec minecraft rcon-cli save-all flush && docker exec minecraft rcon-cli save-off"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_END"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionCommand": {
+            "command": "docker exec minecraft rcon-cli save-on"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_SUCCESS"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=minecraft+backup+complete&priority=Min&tags=white_check_mark",
+            "template": "minecraft backup finished"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_ERROR"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=minecraft+backup+FAILED&priority=Max&tags=skull",
+            "template": "minecraft backup failed{{ if .Error }}: {{ .Error }}{{ end }}"
           }
         }
       ]

--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -93,6 +93,15 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: Minecraft
+    group: Games
+    url: tcp://minecraft:25565
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+    alerts:
+      - type: ntfy
+
   - name: Radarr
     group: Downloads
     url: http://radarr:7878/ping

--- a/apps/minecraft/README.md
+++ b/apps/minecraft/README.md
@@ -1,0 +1,112 @@
+# Minecraft
+
+Private Minecraft cross-play server for a small group, running Paper with
+Geyser and Floodgate on the current pinned game release.
+
+- macOS and other desktop players use Minecraft Java Edition.
+- iOS, Android, and Windows Bedrock players connect through Geyser.
+- Floodgate authenticates Bedrock players with Xbox Live without requiring
+  them to also own Java Edition.
+
+## Access
+
+The server listens directly on TCP `25565` for Java and UDP `19132` for
+Bedrock; neither protocol is routed through Traefik or Cloudflare's HTTP proxy.
+
+Before internet access works:
+
+1. Add two UniFi WAN port-forwards:
+
+   - TCP `25565` to `192.168.4.161:25565` for Java
+   - UDP `19132` to `192.168.4.161:19132` for Bedrock
+
+2. Allow the port on the host:
+
+   ```bash
+   sudo ufw allow 25565/tcp comment 'Minecraft Java'
+   sudo ufw allow 19132/udp comment 'Minecraft Bedrock'
+   ```
+
+3. Create `mc.jaw.dev` as a DNS-only A record pointing at the home WAN IPv4
+   address. Bedrock does not support DNS SRV records.
+
+Connect using:
+
+| Client            | Address         | Port                |
+| ----------------- | --------------- | ------------------- |
+| macOS Java        | `mc.jaw.dev`    | `25565` (default)   |
+| iOS/Bedrock       | `mc.jaw.dev`    | `19132`             |
+| Same-LAN fallback | `192.168.4.161` | Same ports as above |
+
+On iOS, sign in to the Microsoft/Xbox account, open **Play → Servers → Add
+Server**, and enter the Bedrock address and port above.
+
+Keep the DNS record unproxied: Cloudflare's normal HTTP proxy carries neither
+Minecraft's Java TCP protocol nor Bedrock's UDP protocol.
+
+## Player access
+
+Online account authentication and the whitelist are enforced for both editions.
+The initial whitelist is empty, so add each player after deployment.
+
+Java player:
+
+```bash
+docker exec minecraft rcon-cli whitelist add <username>
+```
+
+Bedrock player (use the Xbox gamertag without Floodgate's internal prefix):
+
+```bash
+docker exec minecraft rcon-cli fwhitelist add <gamertag>
+```
+
+Review the combined Java and Floodgate whitelist:
+
+```bash
+docker exec minecraft rcon-cli whitelist list
+```
+
+Grant operator access sparingly. Bedrock names normally use Floodgate's `.` prefix
+for standard Java commands:
+
+```bash
+docker exec minecraft rcon-cli op <username>
+docker exec minecraft rcon-cli op .<bedrock-gamertag>
+```
+
+RCON remains internal to the container and is not published on the host.
+Floodgate generates `/home/jaw/data/minecraft/plugins/floodgate/key.pem`; never
+copy that key into Git or share it.
+
+## Operations
+
+```bash
+docker logs -f minecraft
+docker exec minecraft rcon-cli list
+docker exec minecraft rcon-cli geyser connectiontest mc.jaw.dev 19132
+docker exec minecraft rcon-cli save-all flush
+```
+
+World and server data live at `/home/jaw/data/minecraft`. Backrest flushes and
+pauses world saves around its nightly snapshot, resumes saves afterward, and
+sends the standard success/failure notifications.
+
+The Compose configuration accepts the
+[Minecraft EULA](https://www.minecraft.net/eula).
+
+## Compatibility
+
+Geyser `2.11.0-b1204` supports Bedrock `26.0` through `26.33` and translates
+those clients into Java 26.2 clients. It supports normal vanilla gameplay and
+server-side Paper plugins, but Java-client-only mods and some edition-specific
+behavior cannot be translated perfectly.
+
+Pinned cross-play components:
+
+- Geyser `2.11.0-b1204`
+- Floodgate `2.2.5-b138`
+
+When iOS auto-updates beyond Geyser's supported Bedrock versions, bump both
+plugin download URLs from the official GeyserMC download API and retest before
+deploying.

--- a/apps/minecraft/config/plugins/Geyser-Spigot/config.yml
+++ b/apps/minecraft/config/plugins/Geyser-Spigot/config.yml
@@ -1,0 +1,12 @@
+# Geyser 2.11 configuration managed by home-ops.
+# Unspecified settings use the plugin defaults.
+bedrock:
+  address: 0.0.0.0
+  port: 19132
+  clone-remote-port: false
+
+java:
+  # Floodgate authenticates Xbox Live players without requiring a Java license.
+  auth-type: floodgate
+
+config-version: 7

--- a/apps/minecraft/docker-compose.yml
+++ b/apps/minecraft/docker-compose.yml
@@ -1,0 +1,77 @@
+x-docker-cd:
+  rolling_update: false
+
+services:
+  minecraft:
+    container_name: minecraft
+    image: itzg/minecraft-server:java25@sha256:9e09d64e8cab977f0152e1ca5f75d9ca972617cb946ef2f76acd4348bb950825
+    environment:
+      EULA: "TRUE"
+      TYPE: PAPER
+      VERSION: "26.2"
+      MEMORY: 4G
+      TZ: America/Chicago
+      UID: "1000"
+      GID: "1000"
+      MODE: survival
+      DIFFICULTY: normal
+      MAX_PLAYERS: "8"
+      VIEW_DISTANCE: "10"
+      SIMULATION_DISTANCE: "6"
+      ONLINE_MODE: "TRUE"
+      ENABLE_WHITELIST: "TRUE"
+      ENFORCE_WHITELIST: "TRUE"
+      MOTD: jaw.dev Minecraft
+      PLUGINS: |
+        https://download.geysermc.org/v2/projects/geyser/versions/2.11.0/builds/1204/downloads/spigot
+        https://download.geysermc.org/v2/projects/floodgate/versions/2.2.5/builds/138/downloads/spigot
+      COPY_CONFIG_DEST: /data
+      SYNC_SKIP_NEWER_IN_DESTINATION: "false"
+    volumes:
+      - /home/jaw/data/minecraft:/data
+      - ./config:/config:ro
+    ports:
+      - "25565:25565/tcp"
+      - "19132:19132/udp"
+    networks:
+      - traefik
+    labels:
+      - "traefik.enable=false"
+    healthcheck:
+      test: ["CMD", "mc-health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 2m
+    restart: unless-stopped
+    stop_grace_period: 2m
+    init: true
+    tty: true
+    stdin_open: true
+    read_only: true
+    tmpfs:
+      - /tmp:exec
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "3.0"
+          memory: 6G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  traefik:
+    external: true

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -61,6 +61,7 @@ Per-app schedules are staggered to prevent resource contention. `global` runs la
 
 | App           | Schedule | Type                 | Notes                                                         |
 | ------------- | -------- | -------------------- | ------------------------------------------------------------- |
+| minecraft     | 11:50 PM | Files                | Flushes and pauses world saves during the snapshot            |
 | hello-world   | 12:00 AM | Postgres DB only     |                                                               |
 | immich        | 12:10 AM | Postgres DB only     | Photos at `~/immich` on NFS are not backed up here            |
 | gatus         | 12:20 AM | SQLite + files       | DB file is `gatus.db`                                         |

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,19 +8,21 @@ App-level container requirements live in [Adding Apps](adding-apps.md#container-
 
 Scanned from LAN via `nmap -F <server-ip>`:
 
-| Port  | Service         | Status               | Action                                     |
-| ----- | --------------- | -------------------- | ------------------------------------------ |
-| 22    | SSH             | open                 | Harden through SSH settings                |
-| 80    | HTTP            | open through Traefik | Redirects to HTTPS                         |
-| 443   | HTTPS           | open through Traefik | OK                                         |
-| 111   | rpcbind         | **disabled**         | Unnecessary for NFS v4.1                   |
-| 1883  | MQTT            | open (Zigbee2MQTT)   | Blocked by UFW, Docker-internal only       |
-| 2283  | Immich          | open                 | Blocked by UFW, access via Traefik only    |
-| 8123  | Home Assistant  | open                 | Blocked by UFW, access via Traefik only    |
-| 16992 | Intel AMT HTTP  | open                 | LAN-only remote management                 |
-| 16993 | Intel AMT HTTPS | open                 | LAN-only remote management                 |
-| 5900  | AMT KVM/VNC     | open                 | LAN-only remote screen access              |
-| 32400 | Plex            | open                 | Direct Plex access; bypasses Traefik OAuth |
+| Port  | Service           | Status               | Action                                     |
+| ----- | ----------------- | -------------------- | ------------------------------------------ |
+| 22    | SSH               | open                 | Harden through SSH settings                |
+| 80    | HTTP              | open through Traefik | Redirects to HTTPS                         |
+| 443   | HTTPS             | open through Traefik | OK                                         |
+| 111   | rpcbind           | **disabled**         | Unnecessary for NFS v4.1                   |
+| 1883  | MQTT              | open (Zigbee2MQTT)   | Blocked by UFW, Docker-internal only       |
+| 2283  | Immich            | open                 | Blocked by UFW, access via Traefik only    |
+| 5900  | AMT KVM/VNC       | open                 | LAN-only remote screen access              |
+| 8123  | Home Assistant    | open                 | Blocked by UFW, access via Traefik only    |
+| 16992 | Intel AMT HTTP    | open                 | LAN-only remote management                 |
+| 16993 | Intel AMT HTTPS   | open                 | LAN-only remote management                 |
+| 19132 | Minecraft Bedrock | open (UDP)           | Geyser cross-play; whitelist enforced      |
+| 25565 | Minecraft Java    | open                 | Direct game access; whitelist enforced     |
+| 32400 | Plex              | open                 | Direct Plex access; bypasses Traefik OAuth |
 
 To restrict ports further, change Docker port mappings from `0.0.0.0:PORT:PORT` to `127.0.0.1:PORT:PORT`.
 
@@ -35,10 +37,18 @@ sudo ufw allow 22/tcp    # SSH
 sudo ufw allow 80/tcp    # Traefik HTTP
 sudo ufw allow 443/tcp   # Traefik HTTPS
 sudo ufw allow 32400/tcp # Plex remote access
+sudo ufw allow 25565/tcp # Minecraft Java
+sudo ufw allow 19132/udp # Minecraft Bedrock via Geyser
 sudo ufw enable
 ```
 
 `plex.jaw.dev` is protected by `oauth2-media@file`, but direct access to `<server-ip>:32400` does not pass through Traefik. Keep `32400/tcp` open only if direct Plex client access is required. Close it if Plex must be reachable only through Cloudflare/Traefik/OAuth.
+
+Minecraft is exposed directly on TCP `25565` and Geyser on UDP `19132`;
+Traefik and Cloudflare's HTTP proxy do not protect either protocol. Keep online
+authentication, Floodgate's Xbox Live validation, and the player whitelist
+enabled, and do not publish the internal RCON port or commit Floodgate's
+`key.pem`.
 
 ```bash
 # Management


### PR DESCRIPTION
## Summary

- add a hardened Paper 26.2 Minecraft server sized for a small group
- enable macOS Java and iOS/Bedrock cross-play with pinned Geyser and Floodgate plugins
- enforce online authentication and separate Java/Floodgate whitelist workflows
- add Gatus monitoring and a Backrest plan that flushes and pauses world saves during snapshots
- document firewall, UniFi port forwarding, DNS, operations, recovery, and security requirements

## Why

This provides a self-hosted world for 3–4 players while allowing a macOS Java Edition client and iOS Bedrock Edition clients to play together. Geyser runs inside the Paper container, and Floodgate authenticates Xbox Live users without requiring them to also own Java Edition.

## Validation

- `make format`
- `./scripts/lint.sh` — all repository checks passed; gitleaks was unavailable locally and remains enforced by CI
- `docker compose -f apps/minecraft/docker-compose.yml --project-directory apps/minecraft config -q`
- disposable runtime smoke test confirmed:
  - Paper 26.2 reached healthy status
  - Geyser 2.11.0-b1204 and Floodgate 2.2.5-b138 loaded successfully
  - internal RCON commands worked
  - Geyser listened on UDP `19132`
  - read-only root filesystem and reduced capabilities remained enabled

## After merge

- forward TCP `25565` and UDP `19132` in UniFi to `192.168.4.161`
- allow those ports in UFW
- create a DNS-only `mc.jaw.dev` A record
- add Java players with `whitelist add` and Bedrock players with `fwhitelist add`
