### PR TITLE
feat(music): add Yubal download workflow

### DIFF
--- a/apps/backrest/config/config.json
+++ b/apps/backrest/config/config.json
@@ -546,6 +546,24 @@
       }
     },
     {
+      "id": "yubal",
+      "uri": "/repos/yubal",
+      "password": "",
+      "autoInitialize": true,
+      "prunePolicy": {
+        "schedule": {
+          "cron": "0 6 * * 0"
+        },
+        "maxUnusedPercent": 10
+      },
+      "checkPolicy": {
+        "schedule": {
+          "cron": "0 7 * * 0"
+        },
+        "structureOnly": true
+      }
+    },
+    {
       "id": "global",
       "uri": "/repos/global",
       "password": "",
@@ -2054,6 +2072,54 @@
       ]
     },
     {
+      "id": "yubal",
+      "repo": "yubal",
+      "paths": ["/source/yubal"],
+      "excludes": ["**/yubal/yubal.db", "**/yubal/yubal.db-wal", "**/yubal/yubal.db-shm"],
+      "schedule": {
+        "cron": "0 5 * * *",
+        "clock": "CLOCK_LOCAL"
+      },
+      "retention": {
+        "policyTimeBucketed": {
+          "daily": 7,
+          "weekly": 4,
+          "monthly": 6
+        }
+      },
+      "hooks": [
+        {
+          "conditions": ["CONDITION_SNAPSHOT_START"],
+          "onError": "ON_ERROR_CANCEL",
+          "actionCommand": {
+            "command": "sqlite3 /source/yubal/yubal/yubal.db -cmd \".timeout 30000\" \".backup /source/yubal/.yubal.bak\""
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_END"],
+          "actionCommand": {
+            "command": "rm -f /source/yubal/.yubal.bak"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_SUCCESS"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=yubal+backup+complete&priority=Min&tags=white_check_mark",
+            "template": "yubal backup finished"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_ERROR"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=yubal+backup+FAILED&priority=Max&tags=skull",
+            "template": "yubal backup failed{{ if .Error }}: {{ .Error }}{{ end }}"
+          }
+        }
+      ]
+    },
+    {
       "id": "global",
       "repo": "global",
       "paths": ["/source", "/sops"],
@@ -2066,7 +2132,7 @@
         "**/*.dump"
       ],
       "schedule": {
-        "cron": "0 5 * * *",
+        "cron": "10 5 * * *",
         "clock": "CLOCK_LOCAL"
       },
       "retention": {

--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -93,6 +93,16 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: Yubal
+    group: Media
+    url: http://yubal:8000/api/health
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 3000"
+    alerts:
+      - type: ntfy
+
   - name: Radarr
     group: Downloads
     url: http://radarr:7878/ping

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -2,12 +2,17 @@
     - Plex:
         icon: plex
         href: https://plex.jaw.dev
-        description: Movies & TV
+        description: Movies, TV & Music
         # siteMonitor: http://plex:32400
         # widget:
         #   type: plex
         #   url: http://plex:32400
         #   key: "{{HOMEPAGE_VAR_PLEX_KEY}}"
+
+    - Yubal:
+        icon: youtube-music
+        href: https://yubal.jaw.dev
+        description: YouTube Music Downloader
 
     - Immich:
         icon: immich

--- a/apps/plex/docker-compose.yml
+++ b/apps/plex/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - /home/jaw/plex/movies:/movies
       - /home/jaw/plex/tv:/tv
       - /home/jaw/plex/music:/music
+      - /home/jaw/plex/youtube-music:/youtube-music:ro
     devices:
       - /dev/dri:/dev/dri # Intel Quick Sync (cardN=HDR tone mapping, renderD128=transcode)
     shm_size: "2g" # shared memory for 4K transcoding (default 64MB crashes)

--- a/apps/yubal/README.md
+++ b/apps/yubal/README.md
@@ -1,0 +1,43 @@
+# Yubal
+
+Yubal downloads YouTube Music albums, playlists, and regular YouTube music
+videos into Plex-friendly audio files. The web UI is available at
+`https://yubal.jaw.dev` behind the admin OAuth policy.
+
+## iPhone workflow
+
+1. Create an **unlisted** YouTube playlist named `Burmese Music Inbox`.
+2. Add Burmese songs to it from the YouTube iOS app.
+3. Open Yubal, subscribe to the playlist URL, and start the first sync.
+4. Yubal checks subscriptions daily at 10:00 PM.
+5. Listen in Plexamp after Plex scans the library.
+
+No YouTube cookies are required for public or unlisted playlists. Avoid adding
+account cookies unless a private playlist requires them; cookie-based downloads
+can trigger stricter YouTube account rate limits.
+
+## One-time Plex setup
+
+Create a separate Plex **Music** library named `YouTube Music` and select the
+container path `/youtube-music`. Enable **Prefer local metadata** so Yubal's
+embedded title, artist, album art, lyrics, and Burmese Unicode tags are used.
+Start with 10-20 songs and check their metadata before importing a large list.
+
+The compose configuration deliberately keeps this library separate from
+`/music`, so Lidarr cannot rename or delete YouTube downloads.
+
+## Formats and playlists
+
+Audio is stored as M4A for direct Plex/iOS compatibility. Burmese characters
+are preserved, regular YouTube videos are allowed, ReplayGain is applied, and
+lyrics are fetched when available. Files live on the NAS at
+`/home/jaw/plex/youtube-music`; only Yubal's config and subscription database
+under `/home/jaw/data/yubal` are included in Backrest.
+
+Yubal writes M3U files under `_Playlists`, but Plex does not import M3U files
+itself. If Plex playlists are important, use ListPorter manually after the
+library scan. It needs a Plex token and music library ID, so it is intentionally
+not deployed as an unattended container.
+
+Only archive media you are allowed to download. YouTube extraction can break
+when YouTube changes its site; update Yubal through Renovate when that happens.

--- a/apps/yubal/docker-compose.yml
+++ b/apps/yubal/docker-compose.yml
@@ -1,0 +1,67 @@
+x-docker-cd:
+  rolling_update: false
+
+services:
+  yubal:
+    container_name: yubal
+    # Yubal only publishes release images as latest; pin the v0.9.1 manifest digest.
+    image: ghcr.io/guillevc/yubal:latest@sha256:6701297d9390fac4b1e7b28a916e2552423173ae29e2f562a55af4c14a58859a
+    user: "1000:1000"
+    environment:
+      YUBAL_TZ: America/Chicago
+      YUBAL_AUDIO_FORMAT: m4a
+      YUBAL_AUDIO_QUALITY: "0"
+      YUBAL_ASCII_FILENAMES: "false"
+      YUBAL_DOWNLOAD_UGC: "true"
+      YUBAL_FETCH_LYRICS: "true"
+      YUBAL_REPLAYGAIN: "true"
+      YUBAL_SCHEDULER_ENABLED: "true"
+      YUBAL_SCHEDULER_CRON: "0 22 * * *"
+      YUBAL_CORS_ORIGINS: '["https://yubal.jaw.dev"]'
+      YUBAL_TEMP: /tmp/yubal
+    volumes:
+      - /home/jaw/data/yubal:/app/config
+      - /home/jaw/plex/youtube-music:/app/data
+    networks:
+      - traefik
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health', timeout=5)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    init: true
+    read_only: true
+    tmpfs:
+      - /tmp:size=2G
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.yubal.rule=Host(`yubal.jaw.dev`)"
+      - "traefik.http.routers.yubal.entrypoints=websecure"
+      - "traefik.http.routers.yubal.middlewares=oauth2-admin@file"
+      - "traefik.http.services.yubal.loadbalancer.server.port=8000"
+
+networks:
+  traefik:
+    external: true

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -91,9 +91,10 @@ Per-app schedules are staggered to prevent resource contention. `global` runs la
 | umami         | 4:30 AM  | Postgres DB only     | `pg_dump` via `docker exec umami-db`                          |
 | miniflux      | 4:40 AM  | Postgres DB only     | `pg_dump` via `docker exec miniflux-db`                       |
 | sonarr        | 4:50 AM  | SQLite + files       | Excludes MediaCover, Backups, logs.db, asp, Sentry, \*.pid    |
-| **global**    | 5:00 AM  | All ~/data + ~/.sops | File-level only. Excludes `*.bak`, `*.dump`, backrest state   |
+| yubal         | 5:00 AM  | SQLite + files       | Config only; downloaded music remains on the NAS              |
+| **global**    | 5:10 AM  | All ~/data + ~/.sops | File-level only. Excludes `*.bak`, `*.dump`, backrest state   |
 
-Retention is **7 daily / 4 weekly / 6 monthly** for every plan. Prune runs Sunday 6 AM, integrity check Sunday 7 AM — both after `global` (5:00 AM) finishes, so weekly maintenance never overlaps the daily backups.
+Retention is **7 daily / 4 weekly / 6 monthly** for every plan. Prune runs Sunday 6 AM, integrity check Sunday 7 AM — both after `global` (5:10 AM) finishes, so weekly maintenance never overlaps the daily backups.
 
 ## Adding an App
 
@@ -525,14 +526,14 @@ A formatter has been observed to strip new entries from `config.json` between pu
 
 ```bash
 jq '(.repos | length), (.plans | length)' ~/home-ops/apps/backrest/config/config.json
-# Expect 31 then 31. If either is lower, re-add the missing entries.
+# Expect 32 then 32. If either is lower, re-add the missing entries.
 ```
 
 #### 5. Verify
 
 ```bash
 docker logs backrest --tail 50          # should be no errors after orchestrator starts
-docker exec backrest ls /repos          # should list 31 repos
+docker exec backrest ls /repos          # should list 32 repos
 ```
 
 ### Testing Recovery
@@ -688,7 +689,7 @@ Known issues and their fixes.
 | First backup is very slow                                                                  | No dedup baseline; everything has to be written to the new repo                           | Expected. Subsequent backups are seconds.                                                                                         |
 | Snapshot succeeds but `.bak`/`.dump` lingers in app dir                                    | Post-hook (CONDITION_SNAPSHOT_END) didn't fire or errored                                 | Check the hook's output in the UI. Common cause: wrong filename in the rm command.                                                |
 | ntfy notifications never arrive                                                            | Shoutrrr URL syntax wrong                                                                 | Use `ntfy://ntfy/<topic>?scheme=http&title=foo&priority=Min&tags=skull`. Priority must be capitalized.                            |
-| `config.json` entries disappear after pushing                                              | A formatter strips JSON entries it doesn't recognize                                      | After each push, run `jq '(.repos \| length), (.plans \| length)' ~/home-ops/apps/backrest/config/config.json`. Expect 31 and 31. |
+| `config.json` entries disappear after pushing                                              | A formatter strips JSON entries it doesn't recognize                                      | After each push, run `jq '(.repos \| length), (.plans \| length)' ~/home-ops/apps/backrest/config/config.json`. Expect 32 and 32. |
 | Stateless app got accidentally added to Backrest                                           | Misread of which apps had data                                                            | If `apps/<app>/docker-compose.yml` has no `/home/jaw/data/<app>` volume, skip it. Examples: close-powerlifting, ufc, ip.          |
 
 ## Apps Without Backup

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -174,6 +174,7 @@ STATIC_DIRS=(
 	"$USER_HOME/plex/movies"
 	"$USER_HOME/plex/tv"
 	"$USER_HOME/plex/music"
+	"$USER_HOME/plex/youtube-music"
 	"$USER_HOME/plex/audiobooks"
 	"$USER_HOME/plex/podcasts"
 	"$USER_HOME/.sops"


### PR DESCRIPTION
## Changes

- deploy Yubal behind admin OAuth with a pinned image and hardened runtime
- store downloaded music on the NAS and expose it read-only to Plex
- preserve Burmese Unicode and download regular YouTube music videos as M4A
- add Homepage, Gatus, setup, Backrest, and recovery documentation updates

## Why

This adds an iPhone-friendly path for saving Burmese music from an unlisted YouTube playlist and listening through Plexamp, without letting Lidarr manage the downloaded files.

## Impact

After deployment, create a Plex Music library pointed at /youtube-music and subscribe Yubal to the YouTube playlist. ListPorter remains an optional manual step because it requires a Plex token and library ID.

## Checks

- make format
- Compose configuration validation
- Backrest repo/plan count validation (32/32)
- bash syntax and shfmt checks
- live container startup and /api/health check under non-root, read-only, cap-drop ALL settings
- make lint (all checks passed except shellcheck was unavailable locally; CI installs it)
