### PR TITLE
feat(algo): add operational integrations

### DIFF
--- a/apps/algo/README.md
+++ b/apps/algo/README.md
@@ -7,3 +7,10 @@ The image is built in the dedicated [wajeht/algorithm-visualizer](https://github
 This stack uses the `v1.0.0` image release.
 
 GitHub Gist login and server-side C++/Java execution are intentionally disabled. Upstream C++ execution requires the host Docker socket, and Java execution requires an AWS Lambda deployment.
+
+## Operations
+
+- Gatus monitors `http://algo:8080/api/algorithms` and sends ntfy alerts.
+- Homepage links to `https://algo.jaw.dev` under Tools.
+- The app is stateless, so it does not need a Backrest plan.
+- Version tags in the image repository update this Compose stack through the instant-deploy workflow.

--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -325,6 +325,16 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: Algorithm Visualizer
+    group: Sites
+    url: http://algo:8080/api/algorithms
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 3000"
+    alerts:
+      - type: ntfy
+
   - name: Bang
     group: Sites
     url: http://bang:80/healthz

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -306,6 +306,11 @@
         # siteMonitor: http://hello-world:3000
 
 - Tools:
+    - Algorithm Visualizer:
+        icon: mdi-chart-timeline-variant
+        href: https://algo.jaw.dev
+        description: Interactive Algorithm Visualizations
+
     - DbGate:
         icon: sh-dbgate.png
         href: https://dbgate.jaw.dev

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -696,7 +696,7 @@ Known issues and their fixes.
 
 Apps that don't need backup, by category:
 
-- **Stateless / config-in-image**: `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
+- **Stateless / config-in-image**: `algo`, `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
 - **Cache-only or tiny / no persistent state worth backing up**: `renovate`, `ddns-updater`, `byparr`, `dozzle`, `convertx`, `excalidraw`, `git`, `jaw-dev`, `power-badge`
 - **Config tracked in git**: `backrest`, `oauth2-proxy`, `docker-cd`. The encrypted oauth2-proxy `.env.sops` includes admin and media email allowlists.
 - **Data in object storage**: `linx` — uploads + metadata live in the Garage `linx` bucket, captured by the `garage` plan (no local `~/data/linx`).

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>wajeht/renovate-config"],
+  "ignoreDeps": ["ghcr.io/wajeht/algorithm-visualizer"],
   "hostRules": [
     {
       "matchHost": "ghcr.io",


### PR DESCRIPTION
## Summary

- add Algorithm Visualizer to Homepage
- monitor its internal API with Gatus and ntfy alerts
- document the intentional no-backup decision for the stateless app
- exclude the instant-deployed image from Renovate updates

## Why

The initial app deployment omitted the operational integrations required by the repository's adding-apps and instant-deploy documentation.

## Validation

- `./scripts/lint.sh` (all relevant checks passed; local shell-script check could not run because `shellcheck` is not installed)
- parsed changed YAML with PyYAML
- validated `renovate.json` with `jq`
- `git diff --check`
