### PR TITLE
feat(regexr): add self-hosted regex tester

### DIFF
--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -335,6 +335,16 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: RegExr
+    group: Sites
+    url: http://regexr:8080/healthz
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 3000"
+    alerts:
+      - type: ntfy
+
   - name: Bang
     group: Sites
     url: http://bang:80/healthz

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -311,6 +311,11 @@
         href: https://algo.jaw.dev
         description: Interactive Algorithm Visualizations
 
+    - RegExr:
+        icon: mdi-regex
+        href: https://regex.jaw.dev
+        description: Regular Expression Tester
+
     - DbGate:
         icon: sh-dbgate.png
         href: https://dbgate.jaw.dev

--- a/apps/regexr/README.md
+++ b/apps/regexr/README.md
@@ -1,0 +1,13 @@
+# RegExr
+
+Privacy-focused self-hosted [RegExr](https://github.com/gskinner/regexr) at `https://regex.jaw.dev`.
+
+The GPL-3.0 image is built in the dedicated [wajeht/regexr](https://github.com/wajeht/regexr) repository. JavaScript runs in the browser and PHP/PCRE requests run in the container.
+
+Analytics, advertising, accounts, community storage, and remote save/share are intentionally disabled. The app is stateless and does not need a Backrest plan.
+
+## Operations
+
+- Gatus monitors `http://regexr:8080/healthz` and sends ntfy alerts.
+- Homepage links to `https://regex.jaw.dev` under Tools.
+- Version tags in the image repository update this Compose stack through the instant-deploy workflow.

--- a/apps/regexr/docker-compose.yml
+++ b/apps/regexr/docker-compose.yml
@@ -1,0 +1,48 @@
+x-docker-cd:
+  rolling_update: false
+
+services:
+  regexr:
+    image: ghcr.io/wajeht/regexr:v1.0.0@sha256:b7142288e74933d0a916bc7c004d275a32a2e70d677a73bd0c6a0f1fedd39fe9
+    networks:
+      - traefik
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "php",
+          "-r",
+          'exit(@file_get_contents("http://127.0.0.1:8080/healthz") === "ok\n" ? 0 : 1);',
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    init: true
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.regexr.rule=Host(`regex.jaw.dev`)"
+      - "traefik.http.routers.regexr.entrypoints=websecure"
+      - "traefik.http.routers.regexr.middlewares=rate-limit-global@file"
+      - "traefik.http.services.regexr.loadbalancer.server.port=8080"
+
+networks:
+  traefik:
+    external: true

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -696,7 +696,7 @@ Known issues and their fixes.
 
 Apps that don't need backup, by category:
 
-- **Stateless / config-in-image**: `algo`, `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
+- **Stateless / config-in-image**: `algo`, `regexr`, `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
 - **Cache-only or tiny / no persistent state worth backing up**: `renovate`, `ddns-updater`, `byparr`, `dozzle`, `convertx`, `excalidraw`, `git`, `jaw-dev`, `power-badge`
 - **Config tracked in git**: `backrest`, `oauth2-proxy`, `docker-cd`. The encrypted oauth2-proxy `.env.sops` includes admin and media email allowlists.
 - **Data in object storage**: `linx` — uploads + metadata live in the Garage `linx` bucket, captured by the `garage` plan (no local `~/data/linx`).

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>wajeht/renovate-config"],
-  "ignoreDeps": ["ghcr.io/wajeht/algorithm-visualizer"],
+  "ignoreDeps": ["ghcr.io/wajeht/algorithm-visualizer", "ghcr.io/wajeht/regexr"],
   "hostRules": [
     {
       "matchHost": "ghcr.io",


### PR DESCRIPTION
## Summary

- deploy the dedicated `ghcr.io/wajeht/regexr` image at `regex.jaw.dev`
- add Gatus monitoring and a Homepage entry
- document the stateless backup policy and disable Renovate updates for the digest-managed image

## Validation

- `docker compose -f apps/regexr/docker-compose.yml config --quiet`
- YAML and JSON parsing
- `git diff --check`
- production image health and PHP/PCRE API tests
- repository lint checks pass except local ShellCheck is unavailable
