### PR TITLE
fix(yubal): allow large playlist syncs

### DIFF
--- a/apps/yubal/README.md
+++ b/apps/yubal/README.md
@@ -12,6 +12,8 @@ videos into Plex-friendly audio files. The web UI is available at
 4. Yubal checks subscriptions daily at 10:00 PM.
 5. Listen in Plexamp after Plex scans the library.
 
+Jobs may run for up to six hours so the first sync can process a large playlist.
+
 No YouTube cookies are required for public or unlisted playlists. Avoid adding
 account cookies unless a private playlist requires them; cookie-based downloads
 can trigger stricter YouTube account rate limits.

--- a/apps/yubal/docker-compose.yml
+++ b/apps/yubal/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       YUBAL_DOWNLOAD_UGC: "true"
       YUBAL_FETCH_LYRICS: "true"
       YUBAL_REPLAYGAIN: "true"
+      YUBAL_JOB_TIMEOUT_SECONDS: "21600"
       YUBAL_SCHEDULER_ENABLED: "true"
       YUBAL_SCHEDULER_CRON: "0 22 * * *"
       YUBAL_CORS_ORIGINS: '["https://yubal.jaw.dev"]'


### PR DESCRIPTION
## Changes

- allow Yubal jobs to run for up to six hours
- document the longer window for initial large-playlist syncs

## Why

Yubal defaults to a 30-minute job timeout, which can interrupt the first sync of a large YouTube playlist.

## Impact

Large syncs can finish without changing the nightly schedule or normal download behavior.

## Checks

- Docker Compose configuration validation
- oxfmt formatting check
- git diff check
