### PR TITLE
fix(linx): add dashboard integrations

### DIFF
--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -265,6 +265,16 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: Linx
+    group: Tools
+    url: http://linx:8080
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 3000"
+    alerts:
+      - type: ntfy
+
   - name: Excalidraw
     group: Tools
     url: http://excalidraw:80

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -323,6 +323,12 @@
         description: File Converter
         # siteMonitor: http://convertx:3000
 
+    - Linx:
+        icon: mdi-file-upload
+        href: https://linx.jaw.dev
+        description: File Sharing
+        # siteMonitor: http://linx:8080
+
     - Vaultwarden:
         icon: vaultwarden
         href: https://vault.jaw.dev


### PR DESCRIPTION
## Summary

- add Linx to the Homepage Tools section
- add a Gatus health check with ntfy alerts

## Why

The initial Linx rollout added the service, routing, backups, and secrets, but omitted the two manually maintained dashboard registrations. Homepage and Gatus do not auto-discover new apps.

## Impact

Linx will appear on the home page and its internal HTTP endpoint will be monitored every minute.

## Validation

- `./scripts/lint.sh` (passed; gitleaks unavailable locally and enforced by CI)
- YAML syntax parse for both changed files
- `git diff --check`
