### PR TITLE
feat(calendar): add cal.jaw.dev alias

### DIFF
--- a/apps/calendar/docker-compose.yml
+++ b/apps/calendar/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         max-file: "3"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.calendar.rule=Host(`calendar.jaw.dev`)"
+      - "traefik.http.routers.calendar.rule=Host(`calendar.jaw.dev`) || Host(`cal.jaw.dev`)"
       - "traefik.http.routers.calendar.entrypoints=websecure"
       - "traefik.http.routers.calendar.middlewares=rate-limit-global@file"
       - "traefik.http.services.calendar.loadbalancer.server.port=80"


### PR DESCRIPTION
## Summary

- route `cal.jaw.dev` to the Calendar service
- keep `calendar.jaw.dev` as the existing canonical hostname

## Why

This adds a shorter URL for the personal Calendar without changing the existing route.

## Validation

- `./scripts/lint.sh`
- `git diff --check`
