### PR TITLE
Deploy BJJ roadmap

### DIFF
--- a/apps/bjj-roadmap/docker-compose.yml
+++ b/apps/bjj-roadmap/docker-compose.yml
@@ -1,0 +1,42 @@
+x-docker-cd:
+  rolling_update: true
+
+services:
+  bjj-roadmap:
+    image: ghcr.io/wajeht/roadmap-for-bjj:dba6a72@sha256:5e05f87982c6a101df7a3e7d646ddd0105e931be474cd5644dddcb09f5fa6319
+    networks:
+      - traefik
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    init: true
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 64M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bjj-roadmap.rule=Host(`bjj.jaw.dev`)"
+      - "traefik.http.routers.bjj-roadmap.entrypoints=websecure"
+      - "traefik.http.routers.bjj-roadmap.middlewares=rate-limit-global@file"
+      - "traefik.http.services.bjj-roadmap.loadbalancer.server.port=8080"
+
+networks:
+  traefik:
+    external: true

--- a/apps/gatus/config/config.yaml
+++ b/apps/gatus/config/config.yaml
@@ -335,6 +335,16 @@ endpoints:
     alerts:
       - type: ntfy
 
+  - name: BJJ Roadmap
+    group: Sites
+    url: http://bjj-roadmap:8080/healthz
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 3000"
+    alerts:
+      - type: ntfy
+
   - name: RegExr
     group: Sites
     url: http://regexr:8080/healthz

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -215,6 +215,12 @@
         # siteMonitor: http://umami:3000
 
 - Personal:
+    - BJJ Roadmap:
+        icon: mdi-mixed-martial-arts
+        href: https://bjj.jaw.dev
+        description: Brazilian Jiu-Jitsu Cheat Sheet
+        # siteMonitor: http://bjj-roadmap:8080/healthz
+
     - UFC:
         icon: mdi-mixed-martial-arts
         href: https://ufc.jaw.dev

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -696,7 +696,7 @@ Known issues and their fixes.
 
 Apps that don't need backup, by category:
 
-- **Stateless / config-in-image**: `regexr`, `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
+- **Stateless / config-in-image**: `bjj-roadmap`, `regexr`, `close-powerlifting`, `ufc`, `ip`, `homepage`, `commit`
 - **Cache-only or tiny / no persistent state worth backing up**: `renovate`, `ddns-updater`, `byparr`, `dozzle`, `convertx`, `excalidraw`, `git`, `jaw-dev`, `power-badge`
 - **Config tracked in git**: `backrest`, `oauth2-proxy`, `docker-cd`. The encrypted oauth2-proxy `.env.sops` includes admin and media email allowlists.
 - **Data in object storage**: `linx` — uploads + metadata live in the Garage `linx` bucket, captured by the `garage` plan (no local `~/data/linx`).

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>wajeht/renovate-config"],
-  "ignoreDeps": ["ghcr.io/wajeht/regexr"],
+  "ignoreDeps": ["ghcr.io/wajeht/regexr", "ghcr.io/wajeht/roadmap-for-bjj"],
   "hostRules": [
     {
       "matchHost": "ghcr.io",


### PR DESCRIPTION
## Summary

- deploy the BJJ roadmap image at `bjj.jaw.dev` through Traefik
- add container health, hardening, logging, and resource limits
- register the stateless app in Gatus, Homepage, disaster recovery documentation, and the instant-deploy Renovate ignore list

## Image

- `ghcr.io/wajeht/roadmap-for-bjj:dba6a72`
- `sha256:5e05f87982c6a101df7a3e7d646ddd0105e931be474cd5644dddcb09f5fa6319`

## Validation

- `./scripts/lint.sh`
- `docker compose -f apps/bjj-roadmap/docker-compose.yml --project-directory apps/bjj-roadmap config -q`
- YAML and JSON parsing
- `git diff --check`
