### PR TITLE
feat(course): add deployment

### DIFF
--- a/apps/backrest/config/config.json
+++ b/apps/backrest/config/config.json
@@ -564,6 +564,24 @@
       }
     },
     {
+      "id": "course",
+      "uri": "/repos/course",
+      "password": "",
+      "autoInitialize": true,
+      "prunePolicy": {
+        "schedule": {
+          "cron": "0 6 * * 0"
+        },
+        "maxUnusedPercent": 10
+      },
+      "checkPolicy": {
+        "schedule": {
+          "cron": "0 7 * * 0"
+        },
+        "structureOnly": true
+      }
+    },
+    {
       "id": "global",
       "uri": "/repos/global",
       "password": "",
@@ -2115,6 +2133,53 @@
           "actionShoutrrr": {
             "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=yubal+backup+FAILED&priority=Max&tags=skull",
             "template": "yubal backup failed{{ if .Error }}: {{ .Error }}{{ end }}"
+          }
+        }
+      ]
+    },
+    {
+      "id": "course",
+      "repo": "course",
+      "paths": ["/source/course/.course.bak"],
+      "schedule": {
+        "cron": "20 5 * * *",
+        "clock": "CLOCK_LOCAL"
+      },
+      "retention": {
+        "policyTimeBucketed": {
+          "daily": 7,
+          "weekly": 4,
+          "monthly": 6
+        }
+      },
+      "hooks": [
+        {
+          "conditions": ["CONDITION_SNAPSHOT_START"],
+          "onError": "ON_ERROR_CANCEL",
+          "actionCommand": {
+            "command": "sqlite3 /source/course/course.sqlite -cmd \".timeout 30000\" \".backup /source/course/.course.bak\""
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_END"],
+          "actionCommand": {
+            "command": "rm -f /source/course/.course.bak"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_SUCCESS"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=course+backup+complete&priority=Min&tags=white_check_mark",
+            "template": "course backup finished"
+          }
+        },
+        {
+          "conditions": ["CONDITION_SNAPSHOT_ERROR"],
+          "onError": "ON_ERROR_IGNORE",
+          "actionShoutrrr": {
+            "shoutrrrUrl": "ntfy://ntfy/borgmatic?scheme=http&title=course+backup+FAILED&priority=Max&tags=skull",
+            "template": "course backup failed{{ if .Error }}: {{ .Error }}{{ end }}"
           }
         }
       ]

--- a/apps/course/docker-compose.yml
+++ b/apps/course/docker-compose.yml
@@ -1,0 +1,67 @@
+x-docker-cd:
+  rolling_update: false
+
+services:
+  course:
+    image: ghcr.io/wajeht/course:749936abb51d5bd6593712f1fa89dcf8f65328c8@sha256:49a94555d9c255a728c308505ffba9a0243d79509380ee65227b588143c36dea
+    environment:
+      TZ: America/Chicago
+      APP_ENV: production
+      APP_HOST: 0.0.0.0
+      APP_PORT: 80
+      VIDEOS_DIR: /videos
+      DATA_DIR: /data
+      SCAN_INTERVAL_MS: 300000
+      QSV_DEVICE: /dev/dri/renderD128
+    volumes:
+      - /home/jaw/data/course:/data
+      - /home/jaw/plex/videos:/videos:ro
+    devices:
+      - /dev/dri:/dev/dri
+    networks:
+      - traefik
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:80/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5m
+    restart: unless-stopped
+    stop_grace_period: 30s
+    init: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_OVERRIDE
+      - NET_BIND_SERVICE
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "4.0"
+          memory: 2G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.course.rule=Host(`course.jaw.dev`)"
+      - "traefik.http.routers.course.entrypoints=websecure"
+      - "traefik.http.routers.course.middlewares=oauth2-media@file"
+      - "traefik.http.services.course.loadbalancer.server.port=80"
+
+networks:
+  traefik:
+    external: true

--- a/apps/homepage/config/services.yaml
+++ b/apps/homepage/config/services.yaml
@@ -9,6 +9,11 @@
         #   url: http://plex:32400
         #   key: "{{HOMEPAGE_VAR_PLEX_KEY}}"
 
+    - Course:
+        icon: mdi-school
+        href: https://course.jaw.dev
+        description: Video Courses
+
     - Yubal:
         icon: youtube-music
         href: https://yubal.jaw.dev


### PR DESCRIPTION
## Summary

- deploy the immutable Course image at `course.jaw.dev`
- persist Course data under `/home/jaw/data/course` and mount `/home/jaw/plex/videos` read-only
- enable Intel Quick Sync through `/dev/dri` and protect the route with `oauth2-media@file`
- add Course to Homepage
- add a Backrest plan that snapshots only `course.sqlite`; generated HLS and covers remain rebuildable cache

## Verification

- `./scripts/lint.sh`
- `docker compose -f apps/course/docker-compose.yml config`
- smoke-tested the exact pinned amd64 image with read-only hardening and confirmed `GET /healthz` returns `200`
