### PR TITLE
fix(course): remove Google OAuth

### DIFF
--- a/.github/secrets-rotation.json
+++ b/.github/secrets-rotation.json
@@ -162,7 +162,7 @@
     },
     {
       "id": "App signing secrets",
-      "what": "SESSION_SECRET / JWT_SECRET / cookie secrets / salts across bang, calendar, close-powerlifting, gains, mm2us, notify, convertx, umami, gitea",
+      "what": "SESSION_SECRET / JWT_SECRET / cookie secrets / salts across bang, calendar, close-powerlifting, course, gains, mm2us, notify, convertx, umami, gitea",
       "where": "openssl rand -hex 32 per secret; users re-login after change"
     },
     {

--- a/apps/course/.env.sops
+++ b/apps/course/.env.sops
@@ -1,0 +1,7 @@
+SESSION_SECRET=ENC[AES256_GCM,data:IWXx2mMCTAuzwaoAEkdeyGic46xpKXYXHk/U6g4WbKP9Hyf4DURE2yzdcJ6+vZCs27WF/PahXHRrHRU7+eMrow==,iv:HbLAEGlwRXruAprxjUjLuQPMD5P5dmpaH6znsQyWgo8=,tag:2kWEv+vgY92vgcTe87+EPw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1YUdjUW5ZZnFwVU5UUVAz\nOHZYRUtVUVVaYklRY0RUV2lMYjRnMW1Pdld3CkM2dzk0TFUwWk5FMm94b015OHlp\nT3YzL2pGNzR4cWZkY3lnQXJTQm10Qm8KLS0tIDNvMEZRQ2hkZTMwbVVhOWNIRHJY\nOUErOWk4eXBJOUlERGIzRXJNQTYyVUkKnvnMOA0SrsvdMLIfFOMw+LHVq6eBmwpr\nAp4kLZzcAVNUsHhmhUdeeQNa4/gsZrDrxkil4g1kDS219tpzCFnDuw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1jcnrthtt049n6e2w2hpyq8r342q97r3ws44m0maty4dx527yvd7qyucfnp
+sops_lastmodified=2026-08-11T23:34:55Z
+sops_mac=ENC[AES256_GCM,data:SgY3Huod/YB08x7mqMegojHKfwnuFwfO28+ugbACGhwZPxfnKDNK9pg7/X6gdnkuM0h/ywdQ2cApnqGWii1U+xaYevp8u6YBvkPldCBm0Qc0ShA7g6ZPdBLy7v6s8sZ00um1OSR3/lnHbeccSa2setH6ikFEWglk7sgNLZFEpe4=,iv:l2IYpdn9BMKN77SJmcjFkrtXrxZFJe+4JfL6J2ViE98=,tag:ujla1w0wJDjsb57rY3U4Yg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.11.0

--- a/apps/course/docker-compose.yml
+++ b/apps/course/docker-compose.yml
@@ -4,6 +4,8 @@ x-docker-cd:
 services:
   course:
     image: ghcr.io/wajeht/course:v1.0.21@sha256:024852a45dae023285959cf476dc04a9d6fc19373e6e8664fad09612bc74688a
+    env_file:
+      - .env # docker-cd decrypts .env.sops -> .env (SESSION_SECRET)
     environment:
       TZ: America/Chicago
       APP_ENV: production
@@ -59,7 +61,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.course.rule=Host(`course.jaw.dev`)"
       - "traefik.http.routers.course.entrypoints=websecure"
-      - "traefik.http.routers.course.middlewares=oauth2-media@file"
+      - "traefik.http.routers.course.middlewares=rate-limit-global@file"
       - "traefik.http.services.course.loadbalancer.server.port=80"
 
 networks:


### PR DESCRIPTION
## Summary

- replace Course's `oauth2-media@file` middleware with `rate-limit-global@file`
- add a SOPS-encrypted stable `SESSION_SECRET` required by Course v1.0.21
- include Course in the app-signing-secret rotation inventory

## Why

Course now provides its own password authentication, so the outer Google login is redundant. The current deployment also lacks the required session secret, which prevents the new production container from serving normally.

The existing password remains in Course's persistent SQLite data. The new session secret only requires users to sign in again.

## Verification

- `./scripts/lint.sh`
- `git diff --check`
- parsed `.github/secrets-rotation.json`
- verified the SOPS recipient, encrypted value, and MAC structure
